### PR TITLE
Changed achievement title localization

### DIFF
--- a/src/main/java/betterachievements/gui/GuiBetterAchievements.java
+++ b/src/main/java/betterachievements/gui/GuiBetterAchievements.java
@@ -206,7 +206,7 @@ public class GuiBetterAchievements extends GuiScreen {
         this.drawTexturedModalRect(this.left, this.top + tabHeight / 2, 0, 0, guiWidth, guiHeight);
         this.drawCurrentTab(page);
         this.fontRendererObj.drawString(
-                page.getName() + " " + I18n.format("gui.achievements"),
+                I18n.format("betterachievements.gui.title", page.getName()),
                 this.left + 15,
                 this.top + tabHeight / 2 + 5,
                 4210752);

--- a/src/main/resources/assets/betterachievements/lang/en_US.lang
+++ b/src/main/resources/assets/betterachievements/lang/en_US.lang
@@ -1,4 +1,5 @@
 betterachievements.gui.old=Old Screen
+betterachievements.gui.title=%s Achievements
 betterachievements.config.cantUnlockArrowColour=Can't Unlock Arrow Colour
 betterachievements.config.canUnlockArrowColour=Can Unlock Arrow Colour
 betterachievements.config.completeArrowColour=Completed Arrow Colour

--- a/src/main/resources/assets/betterachievements/lang/zh_CN.lang
+++ b/src/main/resources/assets/betterachievements/lang/zh_CN.lang
@@ -1,4 +1,5 @@
 betterachievements.gui.old=原版界面
+betterachievements.gui.title=%s 成就
 #配置名
 betterachievements.config.cantUnlockArrowColour=无法解锁的成就箭头颜色
 betterachievements.config.canUnlockArrowColour=可解锁的成就箭头颜色


### PR DESCRIPTION
Changed achievement title localization to use the parameter `%s` for `page.getName()`, to be able to recolor that inside the resource pack. In-game looks unchanged all good.


Example:

<img width="1037" height="298" alt="Example" src="https://github.com/user-attachments/assets/26d0dea3-87cd-4776-a095-c9f3dc3dc78a" />
